### PR TITLE
Update to current Actions syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ LABEL com.github.actions.color="green"
 LABEL maintainer="Alberto Gimeno <gimenete@gmail.com>"
 
 COPY lib /action/lib
+COPY package.json /action/lib/package.json
+COPY package-lock.json /action/lib/package.json
 ENTRYPOINT ["/action/lib/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ LABEL maintainer="Alberto Gimeno <gimenete@gmail.com>"
 
 COPY lib /action/lib
 COPY package.json /action/lib/package.json
-COPY package-lock.json /action/lib/package.json
+COPY package-lock.json /action/lib/package-lock.json
 ENTRYPOINT ["/action/lib/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: Jest Snapshots
 author: Alberto Gimeno <gimenete@gmail.com>
 description: Shows Jest Snapshots in the GitHub interface
 inputs:
-  gh-token:
+  GH_TOKEN:
     description: Pass in the GITHUB_TOKEN secret
     required: true
 runs:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,12 @@
+name: Jest Snapshots
+author: Alberto Gimeno <gimenete@gmail.com>
+description: Shows Jest Snapshots in the GitHub interface
+inputs:
+  gh-token:
+    description: Pass in the GITHUB_TOKEN secret
+    required: true
+using: docker
+image: Dockerfile
+branding:
+  icon: aperture
+  color: green

--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,9 @@ inputs:
   gh-token:
     description: Pass in the GITHUB_TOKEN secret
     required: true
-using: docker
-image: Dockerfile
+runs:
+  using: docker
+  image: Dockerfile
 branding:
   icon: aperture
   color: green

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -3,9 +3,6 @@
 set -e
 
 cd /action/lib
-pwd
-echo "looking at package.json"
-cat package.json
 npm install
 
 cd /github/workspace

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+pwd
+echo "looking at package.json"
+cat package.json
 npm install
 
 NODE_PATH=node_modules node /action/lib/run.js

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -2,9 +2,12 @@
 
 set -e
 
+cd /action/lib
 pwd
 echo "looking at package.json"
 cat package.json
 npm install
 
-NODE_PATH=node_modules node /action/lib/run.js
+cd /github/workspace
+
+NODE_PATH=/action/lib/node_modules node /action/lib/run.js

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,7 +1,9 @@
 const request = require('./request')
+const core = require('@actions/core');
 const snapshots = require('./')
 
-const { GITHUB_SHA, GITHUB_EVENT_PATH, GITHUB_TOKEN, GITHUB_WORKSPACE } = process.env
+const { GITHUB_SHA, GITHUB_EVENT_PATH, GITHUB_WORKSPACE } = process.env
+const GITHUB_TOKEN = core.getInput('gh-token', {required: true})
 const event = require(GITHUB_EVENT_PATH)
 const { repository } = event
 const {

--- a/lib/run.js
+++ b/lib/run.js
@@ -3,7 +3,6 @@ const snapshots = require('./')
 
 const { GITHUB_SHA, GITHUB_EVENT_PATH, GITHUB_WORKSPACE, INPUT_GH_TOKEN } = process.env
 const GITHUB_TOKEN = INPUT_GH_TOKEN
-console.log(`GITHUB TOKEN: ${GITHUB_TOKEN}, ${GITHUB_SHA}`)
 const event = require(GITHUB_EVENT_PATH)
 const { repository } = event
 const {

--- a/lib/run.js
+++ b/lib/run.js
@@ -3,6 +3,7 @@ const snapshots = require('./')
 
 const { GITHUB_SHA, GITHUB_EVENT_PATH, GITHUB_WORKSPACE, GH_TOKEN } = process.env
 const GITHUB_TOKEN = GH_TOKEN
+console.log(`GITHUB TOKEN: ${GITHUB_TOKEN}, ${GITHUB_SHA}`)
 const event = require(GITHUB_EVENT_PATH)
 const { repository } = event
 const {

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,8 +1,8 @@
 const request = require('./request')
 const snapshots = require('./')
 
-const { GITHUB_SHA, GITHUB_EVENT_PATH, GITHUB_WORKSPACE, GH_TOKEN } = process.env
-const GITHUB_TOKEN = GH_TOKEN
+const { GITHUB_SHA, GITHUB_EVENT_PATH, GITHUB_WORKSPACE, INPUT_GH_TOKEN } = process.env
+const GITHUB_TOKEN = INPUT_GH_TOKEN
 console.log(`GITHUB TOKEN: ${GITHUB_TOKEN}, ${GITHUB_SHA}`)
 const event = require(GITHUB_EVENT_PATH)
 const { repository } = event

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,9 +1,8 @@
 const request = require('./request')
-const core = require('@actions/core');
 const snapshots = require('./')
 
-const { GITHUB_SHA, GITHUB_EVENT_PATH, GITHUB_WORKSPACE } = process.env
-const GITHUB_TOKEN = core.getInput('gh-token', {required: true})
+const { GITHUB_SHA, GITHUB_EVENT_PATH, GITHUB_WORKSPACE, GH_TOKEN } = process.env
+const GITHUB_TOKEN = GH_TOKEN
 const event = require(GITHUB_EVENT_PATH)
 const { repository } = event
 const {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@actions/core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-ZKdyhlSlyz38S6YFfPnyNgCDZuAF2T0Qv5eHflNWytPS8Qjvz39bZFMry9Bb/dpSnqWcNeav5yM2CTYpJeY+Dw=="
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@actions/core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.0.tgz",
-      "integrity": "sha512-ZKdyhlSlyz38S6YFfPnyNgCDZuAF2T0Qv5eHflNWytPS8Qjvz39bZFMry9Bb/dpSnqWcNeav5yM2CTYpJeY+Dw=="
-    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,5 @@
     "@babel/traverse": "^7.2.3",
     "jest-snapshot": "^24.0.0"
   },
-  "dependencies": {
-    "@actions/core": "^1.2.0"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "@babel/parser": "^7.3.1",
     "@babel/traverse": "^7.2.3",
     "jest-snapshot": "^24.0.0"
+  },
+  "dependencies": {
+    "@actions/core": "^1.2.0"
   }
 }


### PR DESCRIPTION
When attempting to run this I was running into errors, likely as a result of changes to Actions during the preview:

https://github.com/mattdsteele/jest-snapshot-testing/commit/d1e634d1eb56a2ef52b196285f18ded107295481/checks?check_suite_id=293084811#step:6:10

This PR reworks to use `actions.yml` and the current `GITHUB_TOKEN` input process.  A working run: https://github.com/mattdsteele/jest-snapshot-testing/runs/286118363